### PR TITLE
Correcting type for encoding parameter in typescript/fasta

### DIFF
--- a/TypeScript/fasta/fasta.ts
+++ b/TypeScript/fasta/fasta.ts
@@ -7,6 +7,7 @@
  */
 
 type Freq = { s: string; p: number; c: number; sc: number };
+const ENCODING = 'binary';
 
 class Out {
     out_buffer_size: number;
@@ -28,7 +29,7 @@ class Out {
 }
 
 var IM = 139968, IA = 3877, IC = 29573, last = 42;
-var LINE_LEN = 60, NEW_LINE = 10, ENCODING = 'binary';
+var LINE_LEN = 60, NEW_LINE = 10;
 var out = new Out();
 
 function random(): number {


### PR DESCRIPTION
Running old code will result in the following errors:

```
fasta.ts:24:52 - error TS2345: Argument of type 'string' is not assignable to parameter of type 'BufferEncoding'.

24             process.stdout.write(this.buf.toString(ENCODING, 0, this.ct));
                                                      ~~~~~~~~

fasta.ts:42:48 - error TS2345: Argument of type 'string' is not assignable to parameter of type 'BufferEncoding'.

42     out.buf.write(title, out.ct, title.length, ENCODING);
                                                  ~~~~~~~~

fasta.ts:67:48 - error TS2345: Argument of type 'string' is not assignable to parameter of type 'BufferEncoding'.

67     out.buf.write(title, out.ct, title.length, ENCODING);
                                                  ~~~~~~~~
```

Because `BufferEncoding` is an union of string type, and `ENCODING` was defined as a string variable (`var ... ENCODING = 'binary'`), the `BufferEncoding` type was actually a subset of the type of `ENCODING`, thus the error.

This fix defines `ENCODING` as a constant, guaranteeing it to be within the `BufferEncoding` type.

While explicitly coercing as `BufferEncoding` is possible, I don't know where the type is defined to import.